### PR TITLE
Read Description of proposed changes

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -16,6 +16,7 @@ def platform_convert(s):
 
 def generate_url_profile(platform, player):
     """generate link to the website profile"""
+    if platform == 'origin': return f"https://apex.tracker.gg/profile/pc/{player}" # Fixes Issue #29 of improper link sent.
     return f"https://apex.tracker.gg/profile/{platform}/{player}"
 
 def _request(


### PR DESCRIPTION
Added a `
 if platform == 'origin': return f"https://apex.tracker.gg/profile/pc/{player}"`
Since whenever you try to reach the `/origin/` endpoint it returns a Server Down error, I think `/origin/` endpoint was transferred over to `/pc/` endpoint
Anyhow, the default PC platform makes it `origin` in the `{platform}` instead of `pc`
Adding a small `if` can fix it, I hope so.
Can't really test this as I'm proposing these changes at 1:09 AM local time.
And decided to do it as a gesture of kindness, and because you and I know each other, just that my old account got banned.
So yeah.
Have a good one mate, cheers!
This pr fixes Issue #29 